### PR TITLE
Fixed Heroku typo and Venmo dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A curated list of engineering blog of startup and enterprise company.
 * [Grouper](http://eng.joingrouper.com/) - Grouper Engineering Team Blog.
 * [Groupon](https://engineering.groupon.com/) - Groupon Engineering Blog.
 * [Harry's](http://engineering.harrys.com/) - Harry's Engineering.
-* [Heroku](http://engineering.heroku.com/) - Heroke Engineering Blog.
+* [Heroku](http://engineering.heroku.com/) - Heroku Engineering Blog.
 * [HoneyBadger](https://www.honeybadger.io/blog) - HoneyBadger Blog.
 * [HubbleHQ](http://blog.hubblehq.com) - HubbleHQ Blog.
 * [Icehouse](https://www.icehousecorp.com/blog) - Ice House Blog.
@@ -78,7 +78,7 @@ A curated list of engineering blog of startup and enterprise company.
 * [Twilio](https://www.twilio.com/engineering/) - Twilio Engineering.
 * [Thumbtack](http://www.thumbtack.com/engineering/) - Thumbtack Engineering.
 * [Uber](http://eng.uber.com/) - Uber Engineering.
-* [Venmo](http://engineering.venmo.com/) - Venmo Blog.
+* [Venmo](http://blog.venmo.com/) - Venmo Blog.
 * [Wayfair](http://engineering.wayfair.com/) - Wayfair Engineering.
 * [Wealthfront](http://eng.wealthfront.com/) - Wealthfront Engineering.
 * [WebEngage](http://engineering.webengage.com/) - WebEngage Engineering Blog.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A curated list of engineering blog of startup and enterprise company.
 * [Twilio](https://www.twilio.com/engineering/) - Twilio Engineering.
 * [Thumbtack](http://www.thumbtack.com/engineering/) - Thumbtack Engineering.
 * [Uber](http://eng.uber.com/) - Uber Engineering.
-* [Venmo](http://blog.venmo.com/) - Venmo Blog.
+* [Venmo](http://blog.venmo.com/?category=Engineering) - Venmo Blog.
 * [Wayfair](http://engineering.wayfair.com/) - Wayfair Engineering.
 * [Wealthfront](http://eng.wealthfront.com/) - Wealthfront Engineering.
 * [WebEngage](http://engineering.webengage.com/) - WebEngage Engineering Blog.


### PR DESCRIPTION
Found a typo and noticed Venmo's blog link was 404'd so updated to their new blog URL.