### PR TITLE
Add Informed K12 engineering blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A curated list of engineering blogs of startup and enterprise companies.
 | [Import.io](https://www.import.io/blog/)                                       | Import.io Blog.                                         |
 | [Indeed](http://engineering.indeedblog.com/blog/)                              | Indeed Engineering.                                     |
 | [Influxdata](https://influxdata.com/blog/)                                     | Influxdata Blog.                                        |
+| [Informed K12](https://tostring.informedk12.com/)                              | Informed K12 Engineering Blog.                          |
 | [Instacart](https://tech.instacart.com/)                                       | Instacart Tech Blog.                                    |
 | [Instagram](http://instagram-engineering.tumblr.com/)                          | Instagram Engineering.                                  |
 | [IntentHQ](http://engineering.intenthq.com/)                                   | IntentHQ Engineering.                                   |


### PR DESCRIPTION
Adds [Informed K12's](https://www.informedk12.com/) blog to the list.