### PR TITLE
Include diff.blog in tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,5 +205,5 @@ A curated list of engineering blogs of startup and enterprise companies.
 
 | Blog Link                                                                      | Description                                             |
 | ------------------------------------------------------------------------------ | --------------------------------------------------------|
-| [FullJoin.io](https://fulljoin.io)                                             | Search engine for company engineering blogs.            |
+| [diff.blog](https://diff.blog)                                                 | Easy way to follow Engineering and Developer blogs      |
 


### PR DESCRIPTION
Also removed https://fulljoin.io/ from the section since it's not working anymore.

Disclaimer: I built diff.blog. It was launched a year before and I expect to keep it running as long as possible.