### PR TITLE
Add Tally Market Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ A curated list of engineering blogs of startup and enterprise companies.
 | [Stripe](https://stripe.com/blog/engineering)                                  | Stripe Engineering Blog.                                |
 | [Stylight](https://tech.stylight.com/)                                         | Stylight Tech Blog                                      |
 | [Swiggy](https://bytes.swiggy.com/)                                            | Swiggy Engineering                                      |
-| [Tally Market](https://www.tallymarket.co.uk/blog)                             | Tally Market Blog. 
+| [Tally Market](https://www.tallymarket.co.uk/blog)                             | Tally Market 
+Blog.                                               |
 | [TellApart](https://www.tellapart.com/engineering-blog/)                       | TellApart Blog.                                         |
 | [ThoughtWorks](https://www.thoughtworks.com/insights)                          | ThoughtWorks Engineering Blog.                          |
 | [Toptal](https://www.toptal.com/blog)                                          | Toptal Blog.                                            |

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of engineering blogs of startup and enterprise companies.
 | [Stripe](https://stripe.com/blog/engineering)                                  | Stripe Engineering Blog.                                |
 | [Stylight](https://tech.stylight.com/)                                         | Stylight Tech Blog                                      |
 | [Swiggy](https://bytes.swiggy.com/)                                            | Swiggy Engineering                                      |
+| [Tally Market](https://www.tallymarket.co.uk/blog)                             | Tally Market Blog. 
 | [TellApart](https://www.tellapart.com/engineering-blog/)                       | TellApart Blog.                                         |
 | [ThoughtWorks](https://www.thoughtworks.com/insights)                          | ThoughtWorks Engineering Blog.                          |
 | [Toptal](https://www.toptal.com/blog)                                          | Toptal Blog.                                            |

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ A curated list of engineering blogs of startup and enterprise companies.
 | [Stripe](https://stripe.com/blog/engineering)                                  | Stripe Engineering Blog.                                |
 | [Stylight](https://tech.stylight.com/)                                         | Stylight Tech Blog                                      |
 | [Swiggy](https://bytes.swiggy.com/)                                            | Swiggy Engineering                                      |
-| [Tally Market](https://www.tallymarket.co.uk/blog)                             | Tally Market 
-Blog.                                               |
+| [Tally Market](https://www.tallymarket.co.uk/blog)                             | Tally Market Blog.
+                                               |
 | [TellApart](https://www.tellapart.com/engineering-blog/)                       | TellApart Blog.                                         |
 | [ThoughtWorks](https://www.thoughtworks.com/insights)                          | ThoughtWorks Engineering Blog.                          |
 | [Toptal](https://www.toptal.com/blog)                                          | Toptal Blog.                                            |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ A curated list of engineering blogs of startup and enterprise companies.
 | [Stylight](https://tech.stylight.com/)                                         | Stylight Tech Blog                                      |
 | [Swiggy](https://bytes.swiggy.com/)                                            | Swiggy Engineering                                      |
 | [Tally Market](https://www.tallymarket.co.uk/blog)                             | Tally Market Blog.
-                                               |
+                                                    |
 | [TellApart](https://www.tellapart.com/engineering-blog/)                       | TellApart Blog.                                         |
 | [ThoughtWorks](https://www.thoughtworks.com/insights)                          | ThoughtWorks Engineering Blog.                          |
 | [Toptal](https://www.toptal.com/blog)                                          | Toptal Blog.                                            |


### PR DESCRIPTION
Tally Market is a flexible workspace platform that enables individuals and teams to find and instantly book great workspaces across the UK and beyond. Whether you need hot desks, meeting rooms or office space, Tally Market has it.

The Tally Market blog provides news, case studies and guides on finding the perfect workspace, as well as expert advice around full time offices.